### PR TITLE
#35: C type float is not supported in readSDDS

### DIFF
--- a/rsbeams/rsdata/SDDS.py
+++ b/rsbeams/rsdata/SDDS.py
@@ -32,7 +32,7 @@ class readSDDS:
         - No array data (only parameters and columns)
     """
 
-    def __init__(self, input_file, buffer=True, max_string_length=100):
+    def __init__(self, input_file, buffer=True, max_string_length=100, verbose=False):
         """
         Initialize the read in.
 
@@ -46,7 +46,7 @@ class readSDDS:
         max_string_length: Int
             Upper bound on strings that can be read in. Should be at least as large as the biggest string in the file.
         """
-        self.verbose = False
+        self.verbose = verbose
         self.buffer = buffer
         self.openf = open(input_file, 'rb')
         self.position = 0
@@ -162,11 +162,12 @@ class readSDDS:
         for namelist in self.header:
             namelist_type = namelist.split(maxsplit=1)[0]
             try:
-                namelist_data = supported_namelists[namelist_type](namelist)
+                namelist_class = supported_namelists[namelist_type]
             except KeyError:
                 if self.verbose:
                     print(namelist_type, namelist, 'not parsed')
                 continue
+            namelist_data = namelist_class(namelist)
             self.data[namelist_type].append(namelist_data)
 
         if self.data['&data'][0].fields['mode'] == 'ascii':
@@ -386,7 +387,7 @@ class readSDDS:
             else:
                 row_count = self._get_ascii_row_count(position)
 
-            if row_count is 0:
+            if row_count == 0:
                 continue
             if (isinstance(user_pages, GeneratorType) or (page in user_pages)) or self._variable_length_records:
                 column_data, position = self._get_column_data(self._column_keys, position, row_count)

--- a/rsbeams/rsdata/datatypes.py
+++ b/rsbeams/rsdata/datatypes.py
@@ -18,7 +18,12 @@ class Datum:
 
     def set_data_type(self):
         data_type = self.fields['type']
-        self.type_key = data_types[data_type]
+        try:
+            self.type_key = data_types[data_type]
+        except KeyError as error:
+            print(error)
+            print(f'Data type: {data_type} is not supported by readSDDS')
+            raise
 
 
 class Parameter(Datum):
@@ -57,13 +62,21 @@ class Column(Datum):
     def set_data_type(self):
         # Override to account for field_length setting
         data_type = self.fields['type']
+
+        try:
+            type_key = data_types[data_type]
+        except KeyError as error:
+            print(error)
+            print(f'Data type: {data_type} is not supported by readSDDS')
+            raise
+
         if data_type == 'string':
             if self.fields['field_length'] == 0:
-                self.type_key = data_types[data_type]
+                self.type_key = type_key
             else:
-                self.type_key = data_types[data_type].format(np.abs(self.fields['field_length']))
+                self.type_key = type_key.format(np.abs(self.fields['field_length']))
         else:
-            self.type_key = data_types[data_type]
+            self.type_key = type_key
 
 
 class Array(Datum):

--- a/rsbeams/rsdata/utils.py
+++ b/rsbeams/rsdata/utils.py
@@ -3,7 +3,8 @@ import numpy as np
 # TODO: Find sdds use case with 'short' type
 # SDDS defaults to 32 bit unsigned longs on all test systems while numpy uses 64 bits for the np.int_ in test cases
 #  therefore int datatypes are hardcoded in size
-data_types = {'double': np.float64, 'short': np.int16, 'long': np.int32, 'string': 'S{}', 'char': np.char}
+data_types = {'double': np.float64, 'short': np.int16, 'long': np.int32, 'string': 'S{}', 'char': np.char,
+              'float': np.float32}
 
 
 def _return_type(string):

--- a/tests/test_resources/dtype_column.sdds
+++ b/tests/test_resources/dtype_column.sdds
@@ -1,0 +1,5 @@
+SDDS1
+&description text="Error log--input: run.ele  lattice: lattices/dtl_tanks.lte", contents="error log, elegant output" &end
+&associate filename="run.ele", path="/home/vagrant/jupyter/rscon/classifier/data_generation_set1", contents="elegant input, parent" &end
+&column name=ParameterValue, type=notsupported, description="Perturbed value" &end
+&data mode=ascii, lines_per_row=1, no_row_counts=1 &end

--- a/tests/test_resources/dtype_parameter.sdds
+++ b/tests/test_resources/dtype_parameter.sdds
@@ -1,0 +1,6 @@
+SDDS1
+&description text="Error log--input: run.ele  lattice: lattices/dtl_tanks.lte", contents="error log, elegant output" &end
+&associate filename="run.ele", path="/home/vagrant/jupyter/rscon/classifier/data_generation_set1", contents="elegant input, parent" &end
+&parameter name=Step, type=unsupported, description="simulation step" &end
+&data mode=ascii, lines_per_row=1, no_row_counts=1 &end
+0              ! simulation step

--- a/tests/test_sdds_read.py
+++ b/tests/test_sdds_read.py
@@ -317,6 +317,11 @@ class TestParameterRead(unittest.TestCase):
         reader.read()
         print(reader.parameters)
 
+    def test_unsupported_dtype(self):
+        filename = os.path.join(RESOURCE_DIR, 'dtype_parameter.sdds')
+        self.assertRaisesRegex(KeyError, 'unsupported',
+                               readSDDS, filename)
+
 
 class TestColumnRead(unittest.TestCase):
 
@@ -411,6 +416,12 @@ class TestColumnRead(unittest.TestCase):
         reader.read()
         self.assertTrue(reader.columns['t'][0][0] == 1.000000000000000e-02)
         self.assertTrue(reader.columns['t'][0][-1] == 3.335999999999933e+00)
+
+    def test_unsupported_dtype(self):
+        filename = os.path.join(RESOURCE_DIR, 'dtype_column.sdds')
+        self.assertRaisesRegex(KeyError, 'notsupported',
+                               readSDDS, filename)
+
 
 class TestMixedData(unittest.TestCase):
     use_buffer = True


### PR DESCRIPTION
Adds support for `float` SDDS data type, which is the 32-bit float type.
Some better handling for unrecognized data types was also introduced. 