### PR TITLE
41 add brho to kinematic

### DIFF
--- a/rsbeams/rsstats/kinematic.py
+++ b/rsbeams/rsstats/kinematic.py
@@ -5,16 +5,7 @@ import numpy as np
 from scipy.constants import e, c, m_e, physical_constants
 from future.utils import iteritems
 
-# TODO: Priority #1: Need to go back to the principle that user puts in whatever units they desire
-# TODO: cont.  All calculations internall are cgs and then conversion is done to put in the form user requests
-# TODO: Priority #2: Comprehensive set of tests for combinations of input and output units
 
-# ERROR: kinematic -v 299788543.885 --unit SI: This returns numbers that are in eV but the units claim they're SI
-
-# TODO: Add functionality to the Converter class for stand-alone use in scripts/notebooks
-# TODO: Add output conversion to SI units
-# TODO: Dynamically adjust printout to use sensible unit scale? (i.e. not just eV but MeV, GeV, etc if more readable)
-# TODO: Add check when E is given to make sure E>mc**2
 m_e_ev = physical_constants['electron mass energy equivalent in MeV'][0] * 1e6
 m_e_kg = m_e
 ev_per_kg = m_e_ev / m_e_kg

--- a/rsbeams/rsstats/kinematic.py
+++ b/rsbeams/rsstats/kinematic.py
@@ -126,10 +126,10 @@ class Converter:
                 self.mass = m_e_ev
                 self.outputs["mass"] = m_e_ev
         elif self.args['mass_unit'] == "SI":
-            if self.outputs['mass']:
-                self.mass = self.outputs['mass'] * (1 * (self.outputs['input_unit'] == 'SI') + 1 / ev_per_kg * (
-                            self.outputs['input_unit'] == 'eV'))
-                self.outputs["mass"] = self.outputs['mass']
+            if self.args['mass']:
+                self.mass = self.args['mass'] * (1 * (self.args['input_unit'] == 'SI') + ev_per_kg * (
+                            self.args['input_unit'] == 'eV'))
+                self.outputs["mass"] = self.args['mass']
             else:
                 self.mass = m_e_ev
                 self.outputs["mass"] = m_e_ev / ev_per_kg

--- a/rsbeams/rsstats/kinematic.py
+++ b/rsbeams/rsstats/kinematic.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
+
 import sys
 import argparse as arg
 import numpy as np
 from scipy.constants import e, c, m_e, physical_constants
 from future.utils import iteritems
-
 
 m_e_ev = physical_constants['electron mass energy equivalent in MeV'][0] * 1e6
 m_e_kg = m_e
@@ -26,23 +26,24 @@ input.add_argument("-r", "--brho", dest="brho", type=float, help="Input Brho val
 input.add_argument("-b", "--beta", dest="beta", type=float, help="Input beta value. Default unit none")
 input.add_argument("-g", "--gamma", dest="gamma", type=float, help="Input gamma value. Default unit none")
 
-parser.add_argument("-m", "--mass", dest="mass", type=float, help="Optional: Value of particle mass to use.")
+parser.add_argument("-m", "--mass", dest="mass", type=float, help="Optional: Value of particle mass to use. Default "
+                                                                  "mass is for an electron")
 
 parser.add_argument("--mass_unit", dest="mass_unit", choices=["SI", "eV"], default="eV",
                     help="Set mass units. Options are:\n"
-                    "'SI' for standard SI units on all inputs.\n"
-                    "'eV' for the respective electron volt based unit "
-                    "for all inputs.\nDefaults to 'eV'.\n")
+                         "'SI' for standard SI units on all inputs.\n"
+                         "'eV' for the respective electron volt based unit "
+                         "for all inputs.\nDefaults to 'eV'.\n")
 parser.add_argument("--unit", dest="input_unit", choices=["SI", "eV"], default="eV",
                     help="Set input units. Options are:\n"
-                    "'SI' for standard SI units on all inputs.\n"
-                    "'eV' for the respective electron volt based unit "
-                    "for all inputs.\nDefaults to 'eV'.\n")
+                         "'SI' for standard SI units on all inputs.\n"
+                         "'eV' for the respective electron volt based unit "
+                         "for all inputs.\nDefaults to 'eV'.\n")
 parser.add_argument("--output_unit", dest="output_unit", choices=["SI", "eV"], default="eV",
                     help="Set output unit for mass and kinetmatics. Options are:\n"
-                    "'SI' for standard SI units on all outputs.\n"
-                    "'eV' for the respective electron volt based unit "
-                    "for all outputs.\nDefaults to 'eV'.\n")
+                         "'SI' for standard SI units on all outputs.\n"
+                         "'eV' for the respective electron volt based unit "
+                         "for all outputs.\nDefaults to 'eV'.\n")
 
 
 class Converter:
@@ -50,6 +51,7 @@ class Converter:
     Converter works by taking the input kinematic quantity and then always calculating beta and gamma;
     all other kinematic quantity calculations are then performed in terms of beta and gamma.
     """
+
     def __init__(self, momentum=None, velocity=None, energy=None, kenergy=None,
                  betagamma=None, beta=None, gamma=None, brho=None, mass=None,
                  mass_unit='eV', input_unit='eV', output_unit='eV',
@@ -64,14 +66,9 @@ class Converter:
             - Normalized momentum (beta * gamma)
             - Energy
             - Kinetic Energy
+            - Brho
 
-        Currently only works through passing in a parser object with appropriate settings
-        Args:
-            start_parser: Parser object containing necessary settings.
-
-        Returns:
-            None
-            Prints results
+        To use: call instantiated Converter.
         """
         if start_parser:
             args = start_parser.parse_args()
@@ -109,10 +106,12 @@ class Converter:
                         "brho": self.calculate_brho,
                         "beta": None,
                         "gamma": None,
-                        "p_unit": "eV/c" * (self.args['output_unit'] == 'eV') + "kg * m/s" * (self.args['output_unit'] == 'SI'),
+                        "p_unit": "eV/c" * (self.args['output_unit'] == 'eV') + "kg * m/s" * (
+                                    self.args['output_unit'] == 'SI'),
                         "e_unit": "eV" * (self.args['output_unit'] == 'eV') + "J" * (self.args['output_unit'] == 'SI'),
                         "mass": None,
-                        "mass_unit": "eV/c^2" * (self.args['output_unit'] == 'eV') + "kg" * (self.args['output_unit'] == 'SI'),
+                        "mass_unit": "eV/c^2" * (self.args['output_unit'] == 'eV') + "kg" * (
+                                    self.args['output_unit'] == 'SI'),
                         "input": None,
                         "input_unit": None,
                         "input_type": None}
@@ -120,20 +119,25 @@ class Converter:
         # Match mass unit to input units. Print mass in units the user used for input though.
         if self.args['mass_unit'] == "eV":
             if self.args['mass']:
-                self.mass = self.args['mass'] * (1 * (self.args['input_unit'] == 'eV') + 1 / ev_per_kg * (self.args['input_unit'] == 'SI'))
+                self.mass = self.args['mass'] * (
+                            1 * (self.args['input_unit'] == 'eV') + 1 / ev_per_kg * (self.args['input_unit'] == 'SI'))
                 self.outputs["mass"] = self.args['mass']
             else:
                 self.mass = m_e_ev
                 self.outputs["mass"] = m_e_ev
         elif self.args['mass_unit'] == "SI":
             if self.outputs['mass']:
-                self.mass = self.outputs['mass'] * (1 * (self.outputs['input_unit'] == 'SI') + 1 / ev_per_kg * (self.outputs['input_unit'] == 'eV'))
+                self.mass = self.outputs['mass'] * (1 * (self.outputs['input_unit'] == 'SI') + 1 / ev_per_kg * (
+                            self.outputs['input_unit'] == 'eV'))
                 self.outputs["mass"] = self.outputs['mass']
             else:
                 self.mass = m_e_ev
                 self.outputs["mass"] = m_e_ev / ev_per_kg
 
     def __call__(self, *args, silent=False, **kwargs):
+        """Run kinematic conversion.
+        silent (bool): If True then suppress printout and just return values in dict.
+        """
         # Set beta and gamma based on the input value
         for key, value in self.args.items():
             if value is not None and key in self.startup:
@@ -175,7 +179,7 @@ class Converter:
         """
         if self.args['output_unit'] == 'SI':
             self._unit_convert(input_unit='eV', input_dict=self.outputs)
-        
+
         if not silent:
             print(print_string.format(**self.outputs))
 
@@ -255,7 +259,7 @@ class Converter:
 
         gamma = kenergy / self.mass + 1.
 
-        return np.sqrt(1. - 1 / gamma ** 2), gamma
+        return np.sqrt(1. - 1 / gamma**2), gamma
 
     def start_brho(self, brho):
         beta, gamma = self.start_momentum(brho * c)
@@ -295,10 +299,20 @@ class Converter:
         for key in conversion_factors:
             print(key, input_dict[key], (conversion_factors[key]), 2 * (input == 'SI') - 1)
             if input_dict[key]:
-                input_dict[key] = input_dict[key] * (conversion_factors[key])**(2 * (input_unit == 'SI') - 1)
+                input_dict[key] = input_dict[key] * (conversion_factors[key]) ** (2 * (input_unit == 'SI') - 1)
+
+
+def main():
+    """Run from cmd line entrypoint.
+    """
+    if len(sys.argv) == 1:
+        parser.print_help()
+    run_converter = Converter(start_parser=parser)
+    run_converter()
 
 
 if __name__ == "__main__":
+    # Using kinematic as script is deprecated - use entrypoint established by setup.py
     if len(sys.argv) == 1:
         parser.print_help()
     run_converter = Converter(start_parser=parser)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setup(
         'sympy>=1.2',
         'ruamel.yaml'
     ],
+    entry_points={
+        'console_scripts': ['kinematic=rsbeams.rsstats.kinematic:main'],
+    },
     description='Code-agnostic Python utilities for particle beam simulations',
     license='http://www.apache.org/licenses/LICENSE-2.0.html',
     url='https://github.com/radiasoft/rsbeams',

--- a/tests/test_kinematic.py
+++ b/tests/test_kinematic.py
@@ -1,0 +1,32 @@
+from rsbeams.rsstats import kinematic
+import pytest
+"""
+top level cases: outputs / inputs
+    for each: particle type 
+     Read properties for particle type(mass, bet)
+     INSTANTIATE Converter
+        For key in result actually test values
+
+"""
+
+
+
+@pytest.fixture
+def build_converter(request):
+    vals = request.param
+    c = kinematic.Converter(mass=mass, beta=beta, output_unit=output_unit,
+                            input_unit=input_unit, mass_unit=input_mass_unit)
+    return c
+
+
+# @pytest.mark.parametrize("mass", [0.511e6, 938e6])
+# @pytest.mark.parametrize("beta", [0.5, 0.75])
+# def test_meta(mass, beta):
+#     print(mass, beta)
+
+@pytest.mark.parametrize("build_converter", [0.511e6, 938e6], indirect=True)
+@pytest.mark.parametrize("beta,key,expected", [[0.5, 'beta', 0.500], [0.75,'beta', 0.7500]])
+def test_converter_build(build_converter, beta, key, expected,
+                         input_unit='eV', output_unit='eV', input_mass_unit='eV'):
+    c = build_converter
+    assert c[key] == expected

--- a/tests/test_kinematic.py
+++ b/tests/test_kinematic.py
@@ -1,32 +1,31 @@
-from rsbeams.rsstats import kinematic
 import pytest
-"""
-top level cases: outputs / inputs
-    for each: particle type 
-     Read properties for particle type(mass, bet)
-     INSTANTIATE Converter
-        For key in result actually test values
+import numpy
+from rsbeams.rsstats import kinematic
 
-"""
+kinematic_list = [
+        "beta",
+        "momentum",
+    ]
 
+@pytest.mark.parametrize(
+    ("particle_mass", "kinematic_quantity"),
+    [
+        (938.2723e6, {"beta": 0.500, "momentum": 541711642.6722883}),
+        (510998, {"beta": 0.500, "momentum": 295025.381}),
+    ],
+)
+class TestGroup:
 
+    @pytest.fixture
+    def converter(self,  particle_mass: float, kinematic_quantity: dict, k_converter: str) -> kinematic.Converter:
 
-@pytest.fixture
-def build_converter(request):
-    vals = request.param
-    c = kinematic.Converter(mass=mass, beta=beta, output_unit=output_unit,
-                            input_unit=input_unit, mass_unit=input_mass_unit)
-    return c
+        return kinematic.Converter(mass=particle_mass,
+                                   mass_unit='eV',
+                                   input_unit='eV',
+                                   output_unit='eV',
+                                   **{k_converter: kinematic_quantity[k_converter]})
 
-
-# @pytest.mark.parametrize("mass", [0.511e6, 938e6])
-# @pytest.mark.parametrize("beta", [0.5, 0.75])
-# def test_meta(mass, beta):
-#     print(mass, beta)
-
-@pytest.mark.parametrize("build_converter", [0.511e6, 938e6], indirect=True)
-@pytest.mark.parametrize("beta,key,expected", [[0.5, 'beta', 0.500], [0.75,'beta', 0.7500]])
-def test_converter_build(build_converter, beta, key, expected,
-                         input_unit='eV', output_unit='eV', input_mass_unit='eV'):
-    c = build_converter
-    assert c[key] == expected
+    @pytest.mark.parametrize("k_converter", kinematic_list)
+    @pytest.mark.parametrize("k_test", kinematic_list)
+    def test_one(self, k_test,  kinematic_quantity: dict, converter: kinematic.Converter) -> None:
+        assert numpy.isclose(converter(silent=True)[k_test], kinematic_quantity[k_test])

--- a/tests/test_kinematic.py
+++ b/tests/test_kinematic.py
@@ -6,29 +6,32 @@ from pykern import pkjson
 
 
 DATA = pkjson.load_any(open(pathlib.Path("test_resources").joinpath('kinematic_data.json')))
-KINEMATICS_LIST = ["beta", "momentum", "gamma", "momentum", "energy",
+KINEMATICS_OPTIONS = ["beta", "momentum", "gamma", "momentum", "energy",
                   "kenergy", "brho", "velocity", "betagamma"]
-
+UNITS_OPTIONS = ("eV", "SI")
 
 def get_kinematic_quantities(particle_type: str, unit: str) -> dict:
     return DATA[particle_type][unit]["kinematic_quantities"]
 
-@pytest.fixture
-def converter(particle_type: str,  k_converter: str) -> kinematic.Converter:
-    mass_unit = "eV"
-    kinematic_quantity = get_kinematic_quantities(particle_type, unit=mass_unit)
+@pytest.fixture(params=UNITS_OPTIONS)
+def converter(request, particle_type: str,
+              input_unit: str,  output_unit: str, k_converter: str) -> kinematic.Converter:
+    mass_unit = request.param
+    kinematic_quantity = get_kinematic_quantities(particle_type, unit=input_unit)
 
     return kinematic.Converter(mass=DATA[particle_type][mass_unit]['mass'],
                                mass_unit=mass_unit,
-                               input_unit='eV',
-                               output_unit='eV',
+                               input_unit=input_unit,
+                               output_unit=output_unit,
                                **{k_converter: kinematic_quantity[k_converter]})
 
-
+@pytest.mark.parametrize("k_test", KINEMATICS_OPTIONS)
+@pytest.mark.parametrize("k_converter", KINEMATICS_OPTIONS)
+@pytest.mark.parametrize("output_unit", UNITS_OPTIONS)
+@pytest.mark.parametrize("input_unit", UNITS_OPTIONS)
 @pytest.mark.parametrize("particle_type", ("proton", "electron"))
-@pytest.mark.parametrize("k_converter", KINEMATICS_LIST)
-@pytest.mark.parametrize("k_test", KINEMATICS_LIST)
-def test_ev_to_ev(particle_type: str, k_test:str, converter: kinematic.Converter) -> None:
+def test_ev_to_ev(particle_type: str,
+                  input_unit:str, output_unit:str, k_test:str, converter: kinematic.Converter) -> None:
 
-    kinematic_quantity = get_kinematic_quantities(particle_type, unit="eV")
+    kinematic_quantity = get_kinematic_quantities(particle_type, unit=output_unit)
     assert numpy.isclose(converter(silent=True)[k_test], kinematic_quantity[k_test])

--- a/tests/test_resources/kinematic_data.json
+++ b/tests/test_resources/kinematic_data.json
@@ -1,0 +1,36 @@
+{
+  "output_ev": {
+    "proton": {
+      "properties": {
+        "mass": 938.2723e6,
+        "beta": 0.500
+      },
+      "result": {
+        "beta": 0.500,
+        "gamma": 1.155,
+        "momentum": 542.3,
+        "energy": 1083.7,
+        "kenergy": 145.4,
+        "bhro": 1.809,
+        "velocity": 149896229.0,
+        "betagamma": 0.5775
+      }
+    },
+    "electron": {
+      "properties": {
+        "mass":  510998,
+        "beta": 0.500
+      },
+      "result": {
+        "beta": 0.500,
+        "gamma":  1.1547,
+        "momentum": 295025.381,
+        "energy": 590050.7626,
+        "kenergy":  79051.8126,
+        "bhro": 0.0009840,
+        "velocity": 149896229.0,
+        "betagamma":  0.57735026
+      }
+    }
+  }
+}

--- a/tests/test_resources/kinematic_data.json
+++ b/tests/test_resources/kinematic_data.json
@@ -1,35 +1,57 @@
 {
-  "output_ev": {
-    "proton": {
-      "properties": {
-        "mass": 938.2723e6,
-        "beta": 0.500
-      },
-      "result": {
+  "proton": {
+    "eV": {
+      "mass": 938.2723e6,
+      "kinematic_quantities": {
         "beta": 0.500,
-        "gamma": 1.155,
-        "momentum": 542.3,
-        "energy": 1083.7,
-        "kenergy": 145.4,
-        "bhro": 1.809,
+        "gamma": 1.1547005383792517,
+        "momentum": 541711642.6722883,
+        "energy": 1083423285.3445766,
+        "kenergy": 145151197.1845767,
+        "brho": 1.806955539462865,
         "velocity": 149896229.0,
-        "betagamma": 0.5775
+        "betagamma": 0.57735026
       }
     },
-    "electron": {
-      "properties": {
-        "mass":  510998,
-        "beta": 0.500
-      },
-      "result": {
+    "SI": {
+      "mass": 1.67262192369e-27,
+      "kinematic_quantities": {
         "beta": 0.500,
-        "gamma":  1.1547,
-        "momentum": 295025.381,
-        "energy": 590050.7626,
-        "kenergy":  79051.8126,
-        "bhro": 0.0009840,
+        "gamma": 1.1547005383792517,
+        "momentum": 2.8950619440057805e-19,
+        "energy": 1.7358354725115025e-10,
+        "kenergy": 2.325578565263769e-11,
+        "brho": 1.806955539462865,
         "velocity": 149896229.0,
-        "betagamma":  0.57735026
+        "betagamma": 0.57735026
+      }
+    }
+  },
+  "electron": {
+    "eV": {
+      "mass": 510998.94999999995,
+      "kinematic_quantities": {
+        "beta": 0.500,
+        "gamma": 1.1547005383792517,
+        "momentum": 295025.38133811613,
+        "energy": 590050.7626762323,
+        "kenergy": 79051.81267623231,
+        "brho": 0.0009840987438653847,
+        "velocity": 149896229.0,
+        "betagamma": 0.57735026
+      }
+    },
+    "SI": {
+      "mass": 9.1093837015e-31,
+      "kinematic_quantities": {
+        "beta": 0.500,
+        "gamma": 1.1547,
+        "momentum": 1.576700012958035e-22,
+        "energy": 9.453655448266423e-14,
+        "kenergy": 1.2665496714425369e-14,
+        "brho": 0.0009840987438653847,
+        "velocity": 149896229.0,
+        "betagamma": 0.57735026
       }
     }
   }


### PR DESCRIPTION
Adds Brho as an input/output option to the kinematic conversion module.
kinematic command should now be automatically installed.
Creates a set of tests for kinematic module calculations.