### PR TITLE
Fix #55 numpy 2.3+ struct.pack compatibility in SDDS.py

### DIFF
--- a/rsbeams/rsdata/SDDS.py
+++ b/rsbeams/rsdata/SDDS.py
@@ -691,7 +691,7 @@ class writeSDDS:
                         outputFile.write('{}\n'.format(parameter['parData']).encode())
                 if self.dataMode == 'binary':
                         outputFile.write(pack('={}'.format(self.key_indentity[parameter['parType']]),
-                                              parameter['parData']))
+                                              parameter['parData'].item() if hasattr(parameter['parData'], 'item') else parameter['parData']))
 
         # Write row count. Write 0 if no rows.
         if self.dataMode == 'ascii':


### PR DESCRIPTION
- `parameter['parData']` can be a single-element numpy array; numpy 2.3 promoted implicit array-to-scalar conversion from a deprecation warning to an error
- Use `.item()` to extract a Python scalar before passing to `struct.pack`