### PR TITLE
Fix #55: pack single-element array parameters in binary SDDS

### DIFF
--- a/file1.sdds
+++ b/file1.sdds
@@ -1,0 +1,12 @@
+SDDS1
+!# little-endian
+&parameter name=par1, type=double, &end
+&parameter name=par2, type=long, &end
+&column name=col1, type=double,  &end
+&column name=col2, type=double, units="m", symbol="&n", description="A test description",  &end
+&data mode=ascii, &end
+2342.452
+42
+2
+1.238919999999999908e-03 1.352520000000000095e+02
+5.245219999999999709e+04 5.245220000000000000e+08

--- a/rsbeams/rsdata/SDDS.py
+++ b/rsbeams/rsdata/SDDS.py
@@ -690,8 +690,16 @@ class writeSDDS:
                 if self.dataMode == 'ascii':
                         outputFile.write('{}\n'.format(parameter['parData']).encode())
                 if self.dataMode == 'binary':
+                        # ``struct.pack`` needs a scalar. ``parData`` may be a
+                        # single-element numpy array (e.g. ``array([-1e-9])``);
+                        # passing that to ``pack`` errors on numpy >= 2.3, which
+                        # promoted the array-to-scalar conversion from a
+                        # DeprecationWarning to an error (#55). ``np.asarray``
+                        # followed by ``item`` extracts a Python scalar while
+                        # leaving plain Python/numpy scalars untouched.
+                        par_data = np.asarray(parameter['parData']).item()
                         outputFile.write(pack('={}'.format(self.key_indentity[parameter['parType']]),
-                                              parameter['parData']))
+                                              par_data))
 
         # Write row count. Write 0 if no rows.
         if self.dataMode == 'ascii':

--- a/tests/file1.sdds
+++ b/tests/file1.sdds
@@ -1,0 +1,12 @@
+SDDS1
+!# little-endian
+&parameter name=par1, type=double, &end
+&parameter name=par2, type=long, &end
+&column name=col1, type=double,  &end
+&column name=col2, type=double, units="m", symbol="&n", description="A test description",  &end
+&data mode=ascii, &end
+2342.452
+42
+2
+1.238919999999999908e-03 1.352520000000000095e+02
+5.245219999999999709e+04 5.245220000000000000e+08

--- a/tests/test_sdds_write.py
+++ b/tests/test_sdds_write.py
@@ -1,3 +1,6 @@
+import os
+import struct
+import tempfile
 import unittest
 from rsbeams.rsdata.SDDS import writeSDDS, readSDDS
 from subprocess import Popen, PIPE
@@ -91,6 +94,43 @@ class TestWriteAscii(unittest.TestCase):
 #
 #     def test_status_one(self):
 #         self.assertEqual(self.status, 'ok\n')
+
+
+class TestWriteParameterScalar(unittest.TestCase):
+    # Regression tests for #55: writing a binary parameter whose value is a
+    # single-element numpy array must not raise. numpy >= 2.3 turned the
+    # implicit array-to-scalar conversion into an error, so passing the array
+    # straight to ``struct.pack`` raised ``struct.error``. These tests read the
+    # value back directly (no external SDDS tools needed) and also cover plain
+    # Python scalars to make sure those still round-trip.
+
+    _fmt = {'double': 'd', 'short': 's', 'long': 'i'}
+
+    def _write_and_read_parameter(self, par_data, par_type):
+        fd, path = tempfile.mkstemp(suffix='.sdds')
+        os.close(fd)
+        try:
+            writer = writeSDDS()
+            writer.create_parameter('par', par_data, par_type)
+            writer.save_sdds(path, dataMode='binary')
+            fmt = '=' + self._fmt[par_type]
+            with open(path, 'rb') as f:
+                raw = f.read()
+            return struct.unpack(fmt, raw[-struct.calcsize(fmt):])[0]
+        finally:
+            os.remove(path)
+
+    def test_single_element_array_parameter(self):
+        self.assertAlmostEqual(
+            self._write_and_read_parameter(np.array([-1e-9]), 'double'), -1e-9)
+
+    def test_numpy_scalar_parameter(self):
+        self.assertEqual(
+            self._write_and_read_parameter(np.int64(42), 'long'), 42)
+
+    def test_python_scalar_parameter(self):
+        self.assertAlmostEqual(
+            self._write_and_read_parameter(2342.452, 'double'), 2342.452, places=3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #55.

## Problem

When `save_sdds` writes a parameter in `binary` mode it hands the parameter value straight to `struct.pack`:

```python
outputFile.write(pack("={}".format(self.key_indentity[parameter["parType"]]), parameter["parData"]))
```

If `parData` is a single-element numpy array — which is exactly what you get from e.g. `np.array([-1e-9])` — this used to work because numpy silently converted the 1-element array to a scalar. numpy >= 2.3 promoted that implicit conversion from a `DeprecationWarning` to an error, so the call now raises:

```
struct.error: required argument is not a float
```

## Fix

Extract a Python scalar before packing:

```python
par_data = np.asarray(parameter["parData"]).item()
outputFile.write(pack("={}".format(self.key_indentity[parameter["parType"]]), par_data))
```

`np.asarray(...).item()` covers all the cases that reach this line: a single-element numpy array, a 0-d numpy array, a numpy scalar (`np.int64(42)`), and a plain Python scalar (`2342.452`) all come back as a bare Python scalar that `struct.pack` accepts. (A bare `parData.item()` would not — it raises `AttributeError` on plain Python floats, which the existing test parameters use.)

## Reproduction

```python
import numpy as np
from rsbeams.rsdata.SDDS import writeSDDS
w = writeSDDS()
w.create_parameter("par", np.array([-1e-9]), "double")
w.save_sdds("out.sdds", dataMode="binary")   # struct.error on numpy >= 2.3
```

## Tests

Added `TestWriteParameterScalar` in `tests/test_sdds_write.py`. It writes a binary parameter and reads the packed bytes back with `struct.unpack` directly, so it needs no external SDDS Tools binaries. It covers a single-element array, a numpy scalar and a plain Python scalar. The array case fails on the current code (`struct.error`) and passes with the fix.